### PR TITLE
Cleaner redirect

### DIFF
--- a/controllers/clear_cache_clear_cache_controller.php
+++ b/controllers/clear_cache_clear_cache_controller.php
@@ -7,7 +7,7 @@ class ClearCacheClearCacheController extends ClearCacheAppController {
 	public function admin_clear() {
 		$this->ClearCacheClearCache->delete();
 		$this->Session->setFlash(__('Cache has been cleared.', true), 'default', array('class' => 'success'));
-		$this->redirect('/admin');
+		$this->redirect($this->referer());
 	}
 }
 


### PR DESCRIPTION
Not everyone has a page behind the '/admin' route. Redirecting back to the referer page should work for everyone, no matter where you place the link to the clear action.
